### PR TITLE
Replace console logger by ILogger when a background service had a critical error and is shutting down the application.

### DIFF
--- a/src/CriticalBackgroundService.cs
+++ b/src/CriticalBackgroundService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace BetterHostedServices
 {
@@ -20,12 +21,14 @@ namespace BetterHostedServices
         /// Use this if you want to shutdown the application.
         /// </summary>
         protected IApplicationEnder _applicationEnder;
+        private readonly ILogger<CriticalBackgroundService> _logger;
 
         /// <summary>
         /// </summary>
-        protected CriticalBackgroundService(IApplicationEnder applicationEnder)
+        protected CriticalBackgroundService(IApplicationEnder applicationEnder, ILogger<CriticalBackgroundService> logger)
         {
             this._applicationEnder = applicationEnder;
+            this._logger = logger;
         }
 
         /// <summary>
@@ -44,8 +47,8 @@ namespace BetterHostedServices
         /// <param name="exceptionFromExecuteAsync"></param>
         protected virtual void OnError(Exception exceptionFromExecuteAsync)
         {
-            Console.Error.WriteLine($"Error happened while executing CriticalBackgroundTask {this.GetType().FullName}. Shutting down.");
-            Console.Error.WriteLine(exceptionFromExecuteAsync.ToString());
+            this._logger.LogError(exceptionFromExecuteAsync, $"Error happened while executing CriticalBackgroundTask {this.GetType().FullName}. Shutting down.");
+
             this._applicationEnder.ShutDownApplication();
         }
 

--- a/src/PeriodicTaskRunnerBackgroundService.cs
+++ b/src/PeriodicTaskRunnerBackgroundService.cs
@@ -24,15 +24,17 @@ namespace BetterHostedServices
         /// </summary>
         /// <param name="applicationEnder"></param>
         /// <param name="logger"></param>
+        /// <param name="criticalLogger"></param>
         /// <param name="serviceProvider"></param>
         /// <param name="periodicTaskFailureMode"></param>
         /// <param name="timeBetweenTasks"></param>
         public PeriodicTaskRunnerBackgroundService(
             IApplicationEnder applicationEnder,
             ILogger<PeriodicTaskRunnerBackgroundService<TPeriodicTask>> logger,
+            ILogger<CriticalBackgroundService> criticalLogger, 
             IServiceProvider serviceProvider,
             PeriodicTaskFailureMode periodicTaskFailureMode,
-            TimeSpan timeBetweenTasks) : base(applicationEnder)
+            TimeSpan timeBetweenTasks) : base(applicationEnder, criticalLogger)
         {
             this.logger = logger;
             this.serviceProvider = serviceProvider;


### PR DESCRIPTION
There was a log of coding style errors in the repo and it would not build. My modification was pretty small so I did not modify those. I suppose there is a refactoring in progress in a different branch. 
