### PR TITLE
Fix SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: 'Install .NET Core SDK'
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.401
+        dotnet-version: 5.0.206
     - name: 'Dotnet Tool Restore'
       run: dotnet tool restore
       shell: pwsh


### PR DESCRIPTION
It should help with error on build

> A compatible installed .NET Core SDK for global.json version [5.0.206] from [/home/runner/work/BetterHostedServices/BetterHostedServices/global.json] was not found
Install the [5.0.206] .NET Core SDK or update [/home/runner/work/BetterHostedServices/BetterHostedServices/global.json] with an installed .NET Core SDK:
  3.1.401 [/home/runner/.dotnet/sdk]